### PR TITLE
Fixing the error NoMethodError: undefined method `decode' for JSON::JWK:Class

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -134,7 +134,7 @@ module OmniAuth
 
         if options.discovery && kid.present?
           key = config.jwks.select{|k| k["kid"] == kid}.try(:first)
-          JSON::JWK.decode key
+          JSON::JWK.new(key).to_key
         else
           key_or_secret
         end

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt", "~> 1.3.1"
+  spec.add_dependency "jwt", "~> 1.4.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", "~> 1.3.1"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", '= 1.5.2'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt", "= 1.4.0"
+  spec.add_dependency "jwt"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '= 0.7.3'
+  spec.add_dependency 'openid_connect', '~> 1.1'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt", '= 1.5.2'
+  spec.add_dependency 'jwt', '= 1.5.2'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency "jwt", "~> 1.4.0"
+  spec.add_dependency "jwt", "= 1.4.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"


### PR DESCRIPTION
`NoMethodError: undefined method `decode' for JSON::JWK:Class`
So now we can just directly use a initializer instead. 
